### PR TITLE
Add missing dependency in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you want to use the router you should import the `router.createRouter` from `
 
 ```js
 import createStore from 'storeon'
+import useStoreon from 'storeon/react'
 import router from '@storeon/router'
 
 const store = createStore([


### PR DESCRIPTION
`useStoreon` dependency present in https://github.com/storeon/router/blob/master/example-react/App.js#L7 but not in readme.