### PR TITLE
Precise type for createRouter callbacks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,18 @@
 import { StoreonModule } from "storeon";
 
-export type Path = string | RegExp;
-export type Callback = (...props: string[]) => unknown;
-export type Route = [Path, Callback];
+declare namespace createRouter{
+    export type RoutesState<MatchParams> = {
+        [routerKey]: {
+            match: MatchParams
+        }
+    }
+}
 
-export function createRouter<State = unknown>(routes: Route[]): StoreonModule<State>;
+export type Path = string | RegExp;
+export type Callback<MatchParams> = (...props: string[]) => MatchParams;
+export type Route<MatchParam> = [Path, Callback<MatchParam>];
+
+export function createRouter<MatchParam>(routes: Route<MatchParam>[]): StoreonModule<createRouter.RoutesState<MatchParam>>;
 
 export const routerKey: unique symbol;
 export const routerChanged: unique symbol;


### PR DESCRIPTION
What do you think about make createRouter function more precise about its callbacks?

Otherwise you should do more checks when register callbacks and its easy to miss some param when you register routes.